### PR TITLE
Cover template json not exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.1.6
+* javascript のテンプレートが生成できないバグの修正
+
 ## 0.1.5
 * template.json のガイドメッセージ表示機能を追加
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-cli-init",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A module to get your Akashic game started.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/readTemplateFile.ts
+++ b/src/readTemplateFile.ts
@@ -6,16 +6,17 @@ import { TemplateConfig } from "./TemplateConfig";
 export function readTemplateFile(param: InitParameterObject): Promise<TemplateConfig> {
 	const copySpecPath = path.join(param.localTemplateDirectory, param.type, "template.json");
 	return new Promise<TemplateConfig>((resolve, reject) => {
-		fs.readFile(copySpecPath, (err: any, data: any) => { // anyやめる
-			let templateConfig: TemplateConfig = JSON.parse(data);
+		fs.readFile(copySpecPath, (err: any, data: any) => {
 			if (err) {
 				if (err.code !== "ENOENT") {
 					console.log("reg", err);
 					reject(err);
 					return;
 				}
-				templateConfig = {};
+				resolve({});
+				return;
 			}
+			let templateConfig: TemplateConfig = JSON.parse(data);
 			resolve(templateConfig);
 		});
 	});


### PR DESCRIPTION
## このpull requestが解決する内容

`akashic init `でjavascriptのテンプレートが生成できなくなっていた問題を解消します。

## 破壊的な変更を含んでいるか?

なし
