### PR TITLE
fix akashic-cli-config version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "@akashic/akashic-cli-config": "~0.0.4",
+    "@akashic/akashic-cli-config": "~0.1.0",
     "@akashic/akashic-cli-commons": "~0.2.0",
     "commander": "2.8.1",
     "fs-extra": "0.30.0",


### PR DESCRIPTION
## このpull requestが解決する内容

akashic-cli-init 0.2.0は古いバージョンのakashic-cli-configに依存しているため、nodeが利用するnpmとは異なるバージョンのnpmがローカルにインストールされる可能性があります。
このとき、npm scriptsでakashic-cliを利用すると、ローカルにインストールされたnpmが使われるのでnode 7系で正常に動作しません。
npmに依存しないakashic-cli-configを利用すればこの問題を解決できます。

## 修正前の問題を再現する方法

1. node 7.xを用意
2. 下記`package.json`を用意

```
{
  "scripts": {
    "repro": "akashic install @akashic-extension/akashic-timeline"
  },
  "devDependencies": {
    "@akashic/akashic-cli": "1.1.0"
  }
}
```

3. `npm run repro`