### PR TITLE
Update the factory templates for akashic-engine@2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ akashic-cli-init のテンプレートはローカルテンプレートディレ
 `~/.akashic-templates` になります。
 
 ## 設定項目
-akashic-cli init は以下の設定を利用します。設定は `akashic config` コマンドを利用して行います。
+akashic-cli-init は以下の設定を利用します。設定は `akashic config` コマンドを利用して行います。
 * `init.repository`: テンプレート配信サーバのURL。空文字列の時はサーバを利用しない。デフォルトは空文字列。
 * `init.defaultTemplateType`: テンプレートの種類が省略されたときに利用するテンプレート名。デフォルトは `javascript`。
 * `init.localTemplateDirectory`: ローカルファイルシステムでテンプレートを保存する場所。デフォルトは `$HOME/.akashic-templates`。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-cli-init",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "A module to get your Akashic game started.",
   "main": "lib/index.js",
   "scripts": {

--- a/templates-src/javascript/game.json
+++ b/templates-src/javascript/game.json
@@ -9,5 +9,8 @@
 			"path": "script/main.js",
 			"global": true
 		}
+	},
+	"environment": {
+		"sandbox-runtime": "2"
 	}
 }

--- a/templates-src/javascript/package.json
+++ b/templates-src/javascript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "javascript-game-sample",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "",
   "scripts": {
     "start": "akashic-sandbox .",
@@ -11,6 +11,6 @@
   "author": "",
   "license": "",
   "devDependencies": {
-    "@akashic/akashic-sandbox": "^0.12.4"
+    "@akashic/akashic-sandbox": "^0.13.3"
   }
 }

--- a/templates-src/javascript/script/main.js
+++ b/templates-src/javascript/script/main.js
@@ -1,6 +1,6 @@
 function main(param) {
 	const scene = new g.Scene({game: g.game});
-	scene.loaded.handle(function() {
+	scene.loaded.add(function() {
 		// 以下にゲームのロジックを記述します。
 		const rect = new g.FilledRect({
 			scene: scene,
@@ -8,7 +8,7 @@ function main(param) {
 			width: 32,
 			height: 32
 		});
-		rect.update.handle(function () {
+		rect.update.add(function () {
 			// 以下のコードは毎フレーム実行されます。
 			rect.x++;
 			if (rect.x > g.game.width) rect.x = 0;

--- a/templates-src/typescript/README.md
+++ b/templates-src/typescript/README.md
@@ -46,6 +46,6 @@ npm test
 
 ## TypeScriptライブラリ利用時の注意
 
-ゲームにTypeScriptライブラリを利用する場合、このディレクトリで `npm install --save <package_name>` を実行した後、game/以下で `akashic-cli install <package_name>` する必要があります。
+ゲームにTypeScriptライブラリを利用する場合、このディレクトリで `npm install --save <package_name>` を実行した後、game/以下で `akashic install <package_name>` する必要があります。
 これはビルド時(型定義が必要)と実行時(スクリプトが必要)のディレクトリが分かれていることによるものです。
 

--- a/templates-src/typescript/README.md
+++ b/templates-src/typescript/README.md
@@ -17,7 +17,7 @@ npm install
 
 `src` ディレクトリ以下のTypeScriptファイルがコンパイルされ、`game/script` ディレクトリ以下にJavaScriptファイルが生成されます。
 
-`npm run build` は自動的に `akashic-cli scan asset script` を実行するので、`game/game.json` の更新が行われます。
+`npm run build` は自動的に `akashic scan asset script` を実行するので、`game/game.json` の更新が行われます。
 
 ```sh
 npm run build
@@ -46,4 +46,6 @@ npm test
 
 ## TypeScriptライブラリ利用時の注意
 
-ゲームにTypeScriptライブラリを利用する場合、このディレクトリで `npm install --save package_name` を実行した後、game/以下で `akashic-cli install package_name` する必要があります。
+ゲームにTypeScriptライブラリを利用する場合、このディレクトリで `npm install --save <package_name>` を実行した後、game/以下で `akashic-cli install <package_name>` する必要があります。
+これはビルド時(型定義が必要)と実行時(スクリプトが必要)のディレクトリが分かれていることによるものです。
+

--- a/templates-src/typescript/game/game.json
+++ b/templates-src/typescript/game/game.json
@@ -3,5 +3,8 @@
 	"height": 320,
 	"fps": 30,
 	"main": "./script/main.js",
-	"assets": {}
+	"assets": {},
+	"environment": {
+		"sandbox-runtime": "2"
+	}
 }

--- a/templates-src/typescript/package.json
+++ b/templates-src/typescript/package.json
@@ -1,12 +1,10 @@
 {
   "name": "typescript-game-sample",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {
-    "prepublish": "npm run install:typings",
-    "build": "gulp build && cd game && akashic scan asset script",
-    "install:typings": "typings install",
+    "build": "gulp build && cd game && akashic-cli-scan asset script",
     "lint": "gulp lint",
     "start": "akashic-sandbox game",
     "test": "gulp test lint"
@@ -19,6 +17,9 @@
     "index.js"
   ],
   "devDependencies": {
+    "@akashic/akashic-cli-scan": "0.1.3",
+    "@akashic/akashic-engine": "~2.0.0-beta.0",
+    "@akashic/akashic-sandbox": "0.13.3",
     "del": "^1.1.1",
     "gulp": "~3.9.1",
     "gulp-istanbul": "~0.10.4",
@@ -30,10 +31,6 @@
     "jasmine-reporters": "~2.0.4",
     "jasmine-terminal-reporter": "~0.9.1",
     "tslint": "^3.10.2",
-    "typescript": "2.1.6",
-    "typings": "1.0.4",
-    "@akashic/akashic-cli": "1.1.4",
-    "@akashic/akashic-engine": "~1.12.3",
-    "@akashic/akashic-sandbox": "^0.12.4"
+    "typescript": "2.1.6"
   }
 }

--- a/templates-src/typescript/src/main.ts
+++ b/templates-src/typescript/src/main.ts
@@ -1,6 +1,6 @@
 function main(param: g.GameMainParameterObject): void {
 	const scene = new g.Scene({game: g.game});
-	scene.loaded.handle(() => {
+	scene.loaded.add(() => {
 		// 以下にゲームのロジックを記述します。
 		const rect = new g.FilledRect({
 			scene: scene,
@@ -8,7 +8,7 @@ function main(param: g.GameMainParameterObject): void {
 			width: 32,
 			height: 32
 		});
-		rect.update.handle(() => {
+		rect.update.add(() => {
 			// 以下のコードは毎フレーム実行されます。
 			rect.x++;
 			if (rect.x > g.game.width) rect.x = 0;

--- a/templates-src/typescript/tsconfig.json
+++ b/templates-src/typescript/tsconfig.json
@@ -8,7 +8,6 @@
   },
   "files": [
     "node_modules/@akashic/akashic-engine/lib/main.d.ts",
-    "typings/index.d.ts",
     "src/main.ts"
   ]
 }

--- a/templates-src/typescript/typings.json
+++ b/templates-src/typescript/typings.json
@@ -1,7 +1,0 @@
-{
-  "name": "typescript-game-sample",
-  "version": false,
-  "globalDependencies": {
-    "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#58aa81d0f90b118c7dc9e6ab685e4c7aa75f1c72"
-  }
-}


### PR DESCRIPTION
掲題通り。

- templates-src/ 以下の script を更新し、v2系に追従します
- templates-src/ 以下の game.json に environment["sandbox-runtime"] を追加します
- ついでに:
   - 不要な typings.json を排除
   - typo を修正
   - akashic-cli 全体ではなく、akashic-cli-scan のみに依存するように (npm i 負荷軽減)
